### PR TITLE
fix: url encode filename for separated targets

### DIFF
--- a/storage/storage.go
+++ b/storage/storage.go
@@ -390,7 +390,8 @@ func SeparateModTarget(ctx context.Context, body []byte, modID, name, modVersion
 			continue
 		}
 
-		err = copyModFileToArchZip(file, zipWriter, strings.TrimPrefix(file.Name, target+"/"))
+		encodedFileName := EncodeName(strings.TrimPrefix(file.Name, target+"/"))
+		err = copyModFileToArchZip(file, zipWriter, encodedFileName)
 
 		if err != nil {
 			log.Err(err).Msg("failed to add file to " + target + " archive")


### PR DESCRIPTION
https://discord.com/channels/555424930502541343/830842478956642354/1198311921326243962