### PR TITLE
fix: do not add zero-length filenames in per-target zips

### DIFF
--- a/storage/storage.go
+++ b/storage/storage.go
@@ -386,11 +386,15 @@ func SeparateModTarget(ctx context.Context, body []byte, modID, name, modVersion
 	zipWriter := zip.NewWriter(buf)
 
 	for _, file := range zipReader.File {
-		if !strings.HasPrefix(file.Name, target+"/") && file.Name != target+"/" {
+		if !strings.HasPrefix(file.Name, target+"/") {
+			continue
+		}
+		trimmedName := strings.TrimPrefix(file.Name, target+"/")
+		if len(trimmedName) == 0 {
 			continue
 		}
 
-		err = copyModFileToArchZip(file, zipWriter, strings.TrimPrefix(file.Name, target+"/"))
+		err = copyModFileToArchZip(file, zipWriter, trimmedName)
 
 		if err != nil {
 			log.Err(err).Msg("failed to add file to " + target + " archive")


### PR DESCRIPTION
Rewrite the compound conditional to avoid future confusions. This bug has gone unnoticed for so long because Alpakit-generated zip files do not contain folder entries when iterating with a `zipReader`. However, manually generated zip files, e.g. ContentLib mods, could contain folder entries depending on the zipping program used. The resulting zero-length folder in the per-target zips breaks SMM2 on Windows, but not SMM3.