### PR TITLE
fix: urlencode filename for separate mod targets

### DIFF
--- a/storage/storage.go
+++ b/storage/storage.go
@@ -404,7 +404,8 @@ func SeparateModTarget(ctx context.Context, body []byte, modID, name, modVersion
 
 	zipWriter.Close()
 
-	key := fmt.Sprintf("/mods/%s/%s.smod", modID, cleanName+"-"+target+"-"+modVersion)
+	filename := cleanName + "-" + target + "-" + modVersion
+	key := fmt.Sprintf("/mods/%s/%s.smod", modID, filename)
 
 	_, err = storage.Put(ctx, key, bytes.NewReader(buf.Bytes()))
 	if err != nil {
@@ -415,7 +416,8 @@ func SeparateModTarget(ctx context.Context, body []byte, modID, name, modVersion
 	hash := sha256.New()
 	hash.Write(buf.Bytes())
 
-	return true, key, hex.EncodeToString(hash.Sum(nil)), int64(buf.Len())
+	encodedKey := fmt.Sprintf("/mods/%s/%s.smod", modID, EncodeName(filename))
+	return true, encodedKey, hex.EncodeToString(hash.Sum(nil)), int64(buf.Len())
 }
 
 func copyModFileToArchZip(file *zip.File, zipWriter *zip.Writer, newName string) error {

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -276,7 +276,7 @@ func RenameVersion(ctx context.Context, modID string, name string, versionID str
 		return false, ""
 	}
 
-	return true, fmt.Sprintf("/mods/%s/%s.smod", modID, EncodeName(cleanName)+"-"+version)
+	return true, fmt.Sprintf("/mods/%s/%s.smod", modID, EncodeName(cleanName+"-"+version))
 }
 
 func DeleteMod(ctx context.Context, modID string, name string, versionID string) bool {


### PR DESCRIPTION
When a mod's name contains characters that should be urlencoded, any newly-uploaded versions cannot be download because of some errors regarding the URL being invalid. Make sure the returned key is urlencoded for consistency with the rest of the codebase.