### PR TITLE
fix: various issues after ent refactor

### DIFF
--- a/dataloader/loaders.go
+++ b/dataloader/loaders.go
@@ -47,7 +47,7 @@ func Middleware() func(handlerFunc echo.HandlerFunc) echo.HandlerFunc {
 						if u, ok := byID[id]; ok {
 							results[i] = &dataloader.Result[[]*ent.VersionDependency]{Data: u}
 						} else {
-							results[i] = &dataloader.Result[[]*ent.VersionDependency]{Error: errors.New("version not found")}
+							results[i] = &dataloader.Result[[]*ent.VersionDependency]{Data: []*ent.VersionDependency{}}
 						}
 					}
 
@@ -70,7 +70,7 @@ func Middleware() func(handlerFunc echo.HandlerFunc) echo.HandlerFunc {
 						if u, ok := byID[id]; ok {
 							results[i] = &dataloader.Result[[]*ent.UserMod]{Data: u}
 						} else {
-							results[i] = &dataloader.Result[[]*ent.UserMod]{Error: errors.New("version not found")}
+							results[i] = &dataloader.Result[[]*ent.UserMod]{Error: errors.New("mod not found")}
 						}
 					}
 
@@ -97,7 +97,7 @@ func Middleware() func(handlerFunc echo.HandlerFunc) echo.HandlerFunc {
 						if u, ok := byID[id]; ok {
 							results[i] = &dataloader.Result[[]*ent.Version]{Data: u}
 						} else {
-							results[i] = &dataloader.Result[[]*ent.Version]{Error: errors.New("version not found")}
+							results[i] = &dataloader.Result[[]*ent.Version]{Data: []*ent.Version{}}
 						}
 					}
 
@@ -145,7 +145,7 @@ func Middleware() func(handlerFunc echo.HandlerFunc) echo.HandlerFunc {
 						if u, ok := byID[id]; ok {
 							results[i] = &dataloader.Result[[]*ent.Version]{Data: u}
 						} else {
-							results[i] = &dataloader.Result[[]*ent.Version]{Error: errors.New("version not found")}
+							results[i] = &dataloader.Result[[]*ent.Version]{Data: []*ent.Version{}}
 						}
 					}
 

--- a/db/mod.go
+++ b/db/mod.go
@@ -28,15 +28,14 @@ func ConvertModFilter(query *ent.ModQuery, filter *models.ModFilter, count bool,
 
 		if filter.OrderBy != nil && *filter.OrderBy != generated.ModFieldsSearch {
 			if string(*filter.OrderBy) == "last_version_date" {
-				query = query.Modify(func(s *sql.Selector) {
-					s.OrderExpr(sql.ExprP("case when last_version_date is null then 1 else 0 end, last_version_date"))
-				}).Clone()
-			} else {
-				query = query.Order(sql.OrderByField(
-					filter.OrderBy.String(),
-					OrderToOrder(filter.Order.String()),
-				).ToFunc())
+				query = query.Order(func(s *sql.Selector) {
+					s.OrderExpr(sql.ExprP("case when last_version_date is null then 1 else 0 end"))
+				})
 			}
+			query = query.Order(sql.OrderByField(
+				filter.OrderBy.String(),
+				OrderToOrder(filter.Order.String()),
+			).ToFunc())
 		}
 
 		if filter.Search != nil && *filter.Search != "" {

--- a/db/oauth.go
+++ b/db/oauth.go
@@ -3,9 +3,9 @@ package db
 import (
 	"bytes"
 	"context"
-	"github.com/satisfactorymodding/smr-api/generated/ent/predicate"
 
 	"github.com/satisfactorymodding/smr-api/generated/ent"
+	"github.com/satisfactorymodding/smr-api/generated/ent/predicate"
 	"github.com/satisfactorymodding/smr-api/generated/ent/user"
 	"github.com/satisfactorymodding/smr-api/oauth"
 	"github.com/satisfactorymodding/smr-api/storage"

--- a/gql/resolver_guides.go
+++ b/gql/resolver_guides.go
@@ -213,7 +213,7 @@ func convertGuideFilter(query *ent.GuideQuery, filter *models.GuideFilter) *ent.
 				s.Where(sql.P(func(builder *sql.Builder) {
 					builder.WriteString("to_tsvector(name) @@ to_tsquery(").Arg(cleanedSearch).WriteString(")")
 				}))
-			}).Clone()
+			}).GuideQuery
 		}
 
 		if filter.TagIDs != nil && len(filter.TagIDs) > 0 {

--- a/gql/resolver_guides.go
+++ b/gql/resolver_guides.go
@@ -207,8 +207,12 @@ func convertGuideFilter(query *ent.GuideQuery, filter *models.GuideFilter) *ent.
 			).ToFunc())
 
 		if filter.Search != nil && *filter.Search != "" {
+			cleanedSearch := strings.ReplaceAll(*filter.Search, " ", " & ")
+
 			query = query.Modify(func(s *sql.Selector) {
-				s.Where(sql.ExprP("to_tsvector(name) @@ to_tsquery(?)", strings.ReplaceAll(*filter.Search, " ", " & ")))
+				s.Where(sql.P(func(builder *sql.Builder) {
+					builder.WriteString("to_tsvector(name) @@ to_tsquery(").Arg(cleanedSearch).WriteString(")")
+				}))
 			}).Clone()
 		}
 

--- a/gql/resolver_mods.go
+++ b/gql/resolver_mods.go
@@ -244,12 +244,28 @@ func (r *mutationResolver) UpdateMod(ctx context.Context, modID string, updateMo
 				role = "editor"
 			}
 
-			if err := db.From(ctx).UserMod.Create().
-				SetUserID(userMod.UserID).
-				SetModID(modID).
-				SetRole(role).
-				Exec(ctx); err != nil {
-				return nil, err
+			var existing *ent.UserMod
+			for _, author := range authors {
+				if author.UserID == userMod.UserID {
+					existing = author
+					break
+				}
+			}
+
+			if existing != nil {
+				if err := db.From(ctx).UserMod.UpdateOne(existing).
+					SetRole(role).
+					Exec(ctx); err != nil {
+					return nil, err
+				}
+			} else {
+				if err := db.From(ctx).UserMod.Create().
+					SetUserID(userMod.UserID).
+					SetModID(modID).
+					SetRole(role).
+					Exec(ctx); err != nil {
+					return nil, err
+				}
 			}
 		}
 	}

--- a/gql/resolver_sml_versions.go
+++ b/gql/resolver_sml_versions.go
@@ -232,8 +232,12 @@ func convertSMLVersionFilter(query *ent.SmlVersionQuery, filter *models.SMLVersi
 			).ToFunc())
 
 		if filter.Search != nil && *filter.Search != "" {
+			cleanedSearch := strings.ReplaceAll(*filter.Search, " ", " & ")
+
 			query = query.Modify(func(s *sql.Selector) {
-				s.Where(sql.ExprP("to_tsvector(name) @@ to_tsquery(?)", strings.ReplaceAll(*filter.Search, " ", " & ")))
+				s.Where(sql.P(func(builder *sql.Builder) {
+					builder.WriteString("to_tsvector(version) @@ to_tsquery(").Arg(cleanedSearch).WriteString(")")
+				}))
 			}).Clone()
 		}
 	}

--- a/gql/resolver_sml_versions.go
+++ b/gql/resolver_sml_versions.go
@@ -238,7 +238,7 @@ func convertSMLVersionFilter(query *ent.SmlVersionQuery, filter *models.SMLVersi
 				s.Where(sql.P(func(builder *sql.Builder) {
 					builder.WriteString("to_tsvector(version) @@ to_tsquery(").Arg(cleanedSearch).WriteString(")")
 				}))
-			}).Clone()
+			}).SmlVersionQuery
 		}
 	}
 	return query

--- a/gql/resolver_tags.go
+++ b/gql/resolver_tags.go
@@ -95,8 +95,9 @@ func (r *queryResolver) GetTags(ctx context.Context, filter *generated.TagFilter
 			cleanSearch := strings.ReplaceAll(strings.TrimSpace(*filter.Search), " ", " & ")
 
 			query = query.Modify(func(s *sql.Selector) {
-				s.AppendSelectExpr(sql.Expr("similarity(name, ?) as s", cleanSearch))
-				s.Where(sql.ExprP("s > 0.2"))
+				s.Where(sql.P(func(builder *sql.Builder) {
+					builder.WriteString("similarity(name, ").Arg(cleanSearch).WriteString(") > 0.2")
+				}))
 			}).Clone()
 		}
 

--- a/gql/resolver_tags.go
+++ b/gql/resolver_tags.go
@@ -98,7 +98,7 @@ func (r *queryResolver) GetTags(ctx context.Context, filter *generated.TagFilter
 				s.Where(sql.P(func(builder *sql.Builder) {
 					builder.WriteString("similarity(name, ").Arg(cleanSearch).WriteString(") > 0.2")
 				}))
-			}).Clone()
+			}).TagQuery
 		}
 
 		if filter.Ids != nil && len(filter.Ids) > 0 {

--- a/gql/resolver_users.go
+++ b/gql/resolver_users.go
@@ -300,7 +300,7 @@ func (r *userModResolver) User(ctx context.Context, obj *generated.UserMod) (*ge
 }
 
 func (r *userModResolver) Mod(ctx context.Context, obj *generated.UserMod) (*generated.Mod, error) {
-	result, err := db.From(ctx).Mod.Get(ctx, obj.ModID)
+	result, err := db.From(ctx).Mod.Query().WithTags().Where(mod.ID(obj.ModID)).Only(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/gql/resolver_versions.go
+++ b/gql/resolver_versions.go
@@ -478,7 +478,7 @@ func convertVersionFilter(query *ent.VersionQuery, filter *models.VersionFilter,
 				s.Where(sql.P(func(builder *sql.Builder) {
 					builder.WriteString("to_tsvector(version) @@ to_tsquery(").Arg(cleanedSearch).WriteString(")")
 				}))
-			}).Clone()
+			}).VersionQuery
 		}
 	}
 

--- a/gql/resolver_versions.go
+++ b/gql/resolver_versions.go
@@ -472,8 +472,12 @@ func convertVersionFilter(query *ent.VersionQuery, filter *models.VersionFilter,
 			).ToFunc())
 
 		if filter.Search != nil && *filter.Search != "" {
+			cleanedSearch := strings.ReplaceAll(*filter.Search, " ", " & ")
+
 			query = query.Modify(func(s *sql.Selector) {
-				s.Where(sql.ExprP("to_tsvector(name) @@ to_tsquery(?)", strings.ReplaceAll(*filter.Search, " ", " & ")))
+				s.Where(sql.P(func(builder *sql.Builder) {
+					builder.WriteString("to_tsvector(version) @@ to_tsquery(").Arg(cleanedSearch).WriteString(")")
+				}))
 			}).Clone()
 		}
 	}

--- a/migrations/utils/utils.go
+++ b/migrations/utils/utils.go
@@ -16,7 +16,7 @@ func ReindexAllModFiles(ctx context.Context, withMetadata bool, modFilter func(*
 	offset := 0
 
 	for {
-		mods, err := db.From(ctx).Mod.Query().Limit(100).Offset(100).Order(mod.ByCreatedAt(sql.OrderDesc())).All(ctx)
+		mods, err := db.From(ctx).Mod.Query().Limit(100).Offset(offset).Order(mod.ByCreatedAt(sql.OrderDesc())).All(ctx)
 		if err != nil {
 			return err
 		}

--- a/util/converter/converter_windows.go
+++ b/util/converter/converter_windows.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/Vilsol/slox"
 	"github.com/chai2010/webp"
+
 	// GIF Support
 	_ "image/gif"
 	// JPEG Support


### PR DESCRIPTION
* check for either the email or oauth ID matching when logging in
  * in production, logging in was checking if either the email or oauth ID were matching an existing user
  * I changed my email default github email since signing up, so checking that both are equal would not allow me to sign in
  * if checking for both being equal, no account linking would be possible, and the unique email address constraint would also error when logging in with the same email from a different oauth provider
* reindexing mod files was endlessly fetching the 101-200 mods, instead of using the current offset
* query.Clone() discards the effects of Modify, so we take the embedded struct instead, which contains the wanted effects of Modify
  * this was also causing the custom last version date ordering to not have any effect
* build custom predicates that contain arguments with ent methods
  * ent uses PREPARE, and postgres doesn't seem to support question mark arguments in those, even though their docs show that as an example
* query tags in usermod.Mod resolver
  * it's queried on the user page, and the tags field was null, even though the GQL schema specifies a non-null array
  * not really a permanent fix, as there are other places that return a Mod but don't query its tags, resulting in a null tags array
* don't return an error in the dataloader when a mod has no versions, or a version has no dependencies
* check and update existing UserMod entries
  * previously, each authr entry in the updateMod attempted to create a new UserMod entry, which errored because of the unique index