### PR TITLE
fix: restore REST all mod versions response contents

### DIFF
--- a/conversion/ent_to_rest.go
+++ b/conversion/ent_to_rest.go
@@ -1,0 +1,17 @@
+package conversion
+
+import (
+	"github.com/satisfactorymodding/smr-api/generated/ent"
+	"github.com/satisfactorymodding/smr-api/nodes/types"
+)
+
+// goverter:converter
+// goverter:output:file ../generated/conv/version.go
+// goverter:output:package conv
+// goverter:extend TimeToString UIntToInt Int64ToInt
+type ModAllVersions interface {
+	// goverter:map Edges.Targets Targets
+	// goverter:map Edges.VersionDependencies Dependencies
+	Convert(source *ent.Version) *types.ModAllVersionsVersion
+	ConvertSlice(source []*ent.Version) []*types.ModAllVersionsVersion
+}

--- a/conversion/ent_to_rest.go
+++ b/conversion/ent_to_rest.go
@@ -14,4 +14,14 @@ type ModAllVersions interface {
 	// goverter:map Edges.VersionDependencies Dependencies
 	Convert(source *ent.Version) *types.ModAllVersionsVersion
 	ConvertSlice(source []*ent.Version) []*types.ModAllVersionsVersion
+
+	// goverter:map . Link | TargetLink
+	ConvertTarget(source *ent.VersionTarget) *types.ModAllVersionsVersionTarget
+}
+
+func TargetLink(source *ent.VersionTarget) string {
+	if source == nil {
+		return ""
+	}
+	return "/v1/version/" + source.VersionID + "/" + source.TargetName + "/download"
 }

--- a/generated/conv/version.go
+++ b/generated/conv/version.go
@@ -23,7 +23,7 @@ func (c *ModAllVersionsImpl) Convert(source *ent.Version) *types.ModAllVersionsV
 		if (*source).Edges.Targets != nil {
 			pTypesModAllVersionsVersionTargetList = make([]*types.ModAllVersionsVersionTarget, len((*source).Edges.Targets))
 			for i := 0; i < len((*source).Edges.Targets); i++ {
-				pTypesModAllVersionsVersionTargetList[i] = c.pEntVersionTargetToPTypesModAllVersionsVersionTarget((*source).Edges.Targets[i])
+				pTypesModAllVersionsVersionTargetList[i] = c.ConvertTarget((*source).Edges.Targets[i])
 			}
 		}
 		typesModAllVersionsVersion.Targets = pTypesModAllVersionsVersionTargetList
@@ -49,6 +49,19 @@ func (c *ModAllVersionsImpl) ConvertSlice(source []*ent.Version) []*types.ModAll
 	}
 	return pTypesModAllVersionsVersionList
 }
+func (c *ModAllVersionsImpl) ConvertTarget(source *ent.VersionTarget) *types.ModAllVersionsVersionTarget {
+	var pTypesModAllVersionsVersionTarget *types.ModAllVersionsVersionTarget
+	if source != nil {
+		var typesModAllVersionsVersionTarget types.ModAllVersionsVersionTarget
+		typesModAllVersionsVersionTarget.VersionID = (*source).VersionID
+		typesModAllVersionsVersionTarget.TargetName = (*source).TargetName
+		typesModAllVersionsVersionTarget.Link = conversion.TargetLink(source)
+		typesModAllVersionsVersionTarget.Hash = (*source).Hash
+		typesModAllVersionsVersionTarget.Size = conversion.Int64ToInt((*source).Size)
+		pTypesModAllVersionsVersionTarget = &typesModAllVersionsVersionTarget
+	}
+	return pTypesModAllVersionsVersionTarget
+}
 func (c *ModAllVersionsImpl) pEntVersionDependencyToPTypesModAllVersionsVersionDependency(source *ent.VersionDependency) *types.ModAllVersionsVersionDependency {
 	var pTypesModAllVersionsVersionDependency *types.ModAllVersionsVersionDependency
 	if source != nil {
@@ -59,18 +72,6 @@ func (c *ModAllVersionsImpl) pEntVersionDependencyToPTypesModAllVersionsVersionD
 		pTypesModAllVersionsVersionDependency = &typesModAllVersionsVersionDependency
 	}
 	return pTypesModAllVersionsVersionDependency
-}
-func (c *ModAllVersionsImpl) pEntVersionTargetToPTypesModAllVersionsVersionTarget(source *ent.VersionTarget) *types.ModAllVersionsVersionTarget {
-	var pTypesModAllVersionsVersionTarget *types.ModAllVersionsVersionTarget
-	if source != nil {
-		var typesModAllVersionsVersionTarget types.ModAllVersionsVersionTarget
-		typesModAllVersionsVersionTarget.VersionID = (*source).VersionID
-		typesModAllVersionsVersionTarget.TargetName = (*source).TargetName
-		typesModAllVersionsVersionTarget.Hash = (*source).Hash
-		typesModAllVersionsVersionTarget.Size = conversion.Int64ToInt((*source).Size)
-		pTypesModAllVersionsVersionTarget = &typesModAllVersionsVersionTarget
-	}
-	return pTypesModAllVersionsVersionTarget
 }
 
 type VersionImpl struct{}

--- a/generated/conv/version.go
+++ b/generated/conv/version.go
@@ -7,7 +7,71 @@ import (
 	conversion "github.com/satisfactorymodding/smr-api/conversion"
 	generated "github.com/satisfactorymodding/smr-api/generated"
 	ent "github.com/satisfactorymodding/smr-api/generated/ent"
+	types "github.com/satisfactorymodding/smr-api/nodes/types"
 )
+
+type ModAllVersionsImpl struct{}
+
+func (c *ModAllVersionsImpl) Convert(source *ent.Version) *types.ModAllVersionsVersion {
+	var pTypesModAllVersionsVersion *types.ModAllVersionsVersion
+	if source != nil {
+		var typesModAllVersionsVersion types.ModAllVersionsVersion
+		typesModAllVersionsVersion.ID = (*source).ID
+		typesModAllVersionsVersion.Version = (*source).Version
+		typesModAllVersionsVersion.GameVersion = (*source).GameVersion
+		var pTypesModAllVersionsVersionTargetList []*types.ModAllVersionsVersionTarget
+		if (*source).Edges.Targets != nil {
+			pTypesModAllVersionsVersionTargetList = make([]*types.ModAllVersionsVersionTarget, len((*source).Edges.Targets))
+			for i := 0; i < len((*source).Edges.Targets); i++ {
+				pTypesModAllVersionsVersionTargetList[i] = c.pEntVersionTargetToPTypesModAllVersionsVersionTarget((*source).Edges.Targets[i])
+			}
+		}
+		typesModAllVersionsVersion.Targets = pTypesModAllVersionsVersionTargetList
+		var pTypesModAllVersionsVersionDependencyList []*types.ModAllVersionsVersionDependency
+		if (*source).Edges.VersionDependencies != nil {
+			pTypesModAllVersionsVersionDependencyList = make([]*types.ModAllVersionsVersionDependency, len((*source).Edges.VersionDependencies))
+			for j := 0; j < len((*source).Edges.VersionDependencies); j++ {
+				pTypesModAllVersionsVersionDependencyList[j] = c.pEntVersionDependencyToPTypesModAllVersionsVersionDependency((*source).Edges.VersionDependencies[j])
+			}
+		}
+		typesModAllVersionsVersion.Dependencies = pTypesModAllVersionsVersionDependencyList
+		pTypesModAllVersionsVersion = &typesModAllVersionsVersion
+	}
+	return pTypesModAllVersionsVersion
+}
+func (c *ModAllVersionsImpl) ConvertSlice(source []*ent.Version) []*types.ModAllVersionsVersion {
+	var pTypesModAllVersionsVersionList []*types.ModAllVersionsVersion
+	if source != nil {
+		pTypesModAllVersionsVersionList = make([]*types.ModAllVersionsVersion, len(source))
+		for i := 0; i < len(source); i++ {
+			pTypesModAllVersionsVersionList[i] = c.Convert(source[i])
+		}
+	}
+	return pTypesModAllVersionsVersionList
+}
+func (c *ModAllVersionsImpl) pEntVersionDependencyToPTypesModAllVersionsVersionDependency(source *ent.VersionDependency) *types.ModAllVersionsVersionDependency {
+	var pTypesModAllVersionsVersionDependency *types.ModAllVersionsVersionDependency
+	if source != nil {
+		var typesModAllVersionsVersionDependency types.ModAllVersionsVersionDependency
+		typesModAllVersionsVersionDependency.ModID = (*source).ModID
+		typesModAllVersionsVersionDependency.Condition = (*source).Condition
+		typesModAllVersionsVersionDependency.Optional = (*source).Optional
+		pTypesModAllVersionsVersionDependency = &typesModAllVersionsVersionDependency
+	}
+	return pTypesModAllVersionsVersionDependency
+}
+func (c *ModAllVersionsImpl) pEntVersionTargetToPTypesModAllVersionsVersionTarget(source *ent.VersionTarget) *types.ModAllVersionsVersionTarget {
+	var pTypesModAllVersionsVersionTarget *types.ModAllVersionsVersionTarget
+	if source != nil {
+		var typesModAllVersionsVersionTarget types.ModAllVersionsVersionTarget
+		typesModAllVersionsVersionTarget.VersionID = (*source).VersionID
+		typesModAllVersionsVersionTarget.TargetName = (*source).TargetName
+		typesModAllVersionsVersionTarget.Hash = (*source).Hash
+		typesModAllVersionsVersionTarget.Size = conversion.Int64ToInt((*source).Size)
+		pTypesModAllVersionsVersionTarget = &typesModAllVersionsVersionTarget
+	}
+	return pTypesModAllVersionsVersionTarget
+}
 
 type VersionImpl struct{}
 

--- a/nodes/mod.go
+++ b/nodes/mod.go
@@ -486,5 +486,5 @@ func getAllModVersions(c echo.Context) (interface{}, *ErrorResponse) {
 		return nil, &ErrorVersionNotFound
 	}
 
-	return (*conv.VersionImpl)(nil).ConvertSlice(versions), nil
+	return (*conv.ModAllVersionsImpl)(nil).ConvertSlice(versions), nil
 }

--- a/nodes/mod.go
+++ b/nodes/mod.go
@@ -476,7 +476,7 @@ func getAllModVersions(c echo.Context) (interface{}, *ErrorResponse) {
 	}
 
 	versions, err := mod.QueryVersions().
-		WithDependencies().
+		WithVersionDependencies().
 		WithTargets().
 		Where(version2.Approved(true), version2.Denied(false)).
 		Select(version2.FieldHash, version2.FieldSize, version2.FieldGameVersion, version2.FieldVersion).

--- a/nodes/mod.go
+++ b/nodes/mod.go
@@ -479,7 +479,7 @@ func getAllModVersions(c echo.Context) (interface{}, *ErrorResponse) {
 		WithDependencies().
 		WithTargets().
 		Where(version2.Approved(true), version2.Denied(false)).
-		Select(version2.FieldHash, version2.FieldSize, version2.FieldVersion).
+		Select(version2.FieldHash, version2.FieldSize, version2.FieldGameVersion, version2.FieldVersion).
 		All(c.Request().Context())
 	if err != nil {
 		slox.Error(c.Request().Context(), "failed fetching versions", slog.Any("err", err))

--- a/nodes/types/mod_types.go
+++ b/nodes/types/mod_types.go
@@ -11,6 +11,7 @@ type ModAllVersionsVersion struct {
 type ModAllVersionsVersionTarget struct {
 	VersionID  string `json:"version_id"`
 	TargetName string `json:"target_name"`
+	Link       string `json:"link"`
 	Hash       string `json:"hash"`
 	Size       int    `json:"size"`
 }

--- a/nodes/types/mod_types.go
+++ b/nodes/types/mod_types.go
@@ -1,0 +1,22 @@
+package types
+
+type ModAllVersionsVersion struct {
+	ID           string                             `json:"id"`
+	Version      string                             `json:"version"`
+	GameVersion  string                             `json:"game_version"`
+	Targets      []*ModAllVersionsVersionTarget     `json:"targets"`
+	Dependencies []*ModAllVersionsVersionDependency `json:"dependencies"`
+}
+
+type ModAllVersionsVersionTarget struct {
+	VersionID  string `json:"version_id"`
+	TargetName string `json:"target_name"`
+	Hash       string `json:"hash"`
+	Size       int    `json:"size"`
+}
+
+type ModAllVersionsVersionDependency struct {
+	ModID     string `json:"mod_id"`
+	Condition string `json:"condition"`
+	Optional  bool   `json:"optional"`
+}


### PR DESCRIPTION
Since the ent refactor, the dependencies list was null, and a lot of blank fields were returned, because a GraphQL response type was used, but was not filled in.

Also adds a Link field to the targets in the response, like the Link in the Version type on the GraphQL API, such that ficsit-resolver doesn't need to construct the downloads links based on the version ID and target name.